### PR TITLE
Handle ack vs ack-grep

### DIFF
--- a/ack/bootstrap.sh
+++ b/ack/bootstrap.sh
@@ -6,4 +6,5 @@ install_ack() {
     fi
 }
 
-install_ack
+# check for existence of ack first
+hash ack 2>/dev/null || install_ack

--- a/aliases/aliases
+++ b/aliases/aliases
@@ -14,6 +14,8 @@ alias solarize="source ~/.solarize"
 
 #some more aliases
 alias l='ls -alF'
-alias ack="ack-grep"
+if hash ack-grep 2>/dev/null; then
+    alias ack="ack-grep"
+fi
 alias no-pyc-files="find . -name '*.pyc' | xargs rm -f"
 alias clean_git="git clean -n | sed 's/Would remove //' | xargs -L 1 --replace=$ mv $ cruft"


### PR DESCRIPTION
Only attempt to install `ack-grep` if on linux.

Only alias `ack` to `ack-grep` if `ack-grep` is installed.

These are necessary to support OSX `ack` :disappointed: 
