### PR TITLE
Support xterm256-color

### DIFF
--- a/bash/bashrc
+++ b/bash/bashrc
@@ -1,8 +1,10 @@
 # set a fancy prompt (non-color, unless we know we "want" color)
 case "$TERM" in
-    xterm-color) color_prompt=yes;;
+    xterm-color)
+        color_prompt=yes;;
+    xterm256-color)
+        color_prompt=yes;;
 esac
-
 
 # uncomment for a colored prompt, if the terminal has the capability; turned
 # off by default to not distract the user: the focus in a terminal window


### PR DESCRIPTION
For a xterm256-color terminal, such as iTerm with a Solarized
preset loaded, this change was necessary to allow vim
to work, particularly as the editor for git
